### PR TITLE
Install 'sphinx-apidoc' and 'sphinx-autogen' scripts.

### DIFF
--- a/src/collective/recipe/sphinxbuilder/__init__.py
+++ b/src/collective/recipe/sphinxbuilder/__init__.py
@@ -139,7 +139,9 @@ class Recipe(object):
         requirements, ws = self.egg.working_set([self.options['recipe'], 'docutils'])
         zc.buildout.easy_install.scripts(
                 [('sphinx-quickstart', 'sphinx.quickstart', 'main'),
-                 ('sphinx-build', 'sphinx', 'main')], ws,
+                 ('sphinx-build', 'sphinx', 'main'),
+                 ('sphinx-apidoc', 'sphinx.apidoc', 'main'),
+                 ('sphinx-autogen', 'sphinx.ext.autosummary.generate', 'main')], ws,
                 self.buildout[self.buildout['buildout']['python']]['executable'],
                 self.bin_dir, **egg_options)
 


### PR DESCRIPTION
Minor change to include `sphinx-apidoc` and `sphinx-autogen` in the list of scripts installed to `bin`.
