### PR TITLE
Fixed .rst formatting error

### DIFF
--- a/src/collective/recipe/sphinxbuilder/docs/usage.rst
+++ b/src/collective/recipe/sphinxbuilder/docs/usage.rst
@@ -206,6 +206,7 @@ Again, we will skip running them, this time to avoid a recursive fork bomb. ;)
 
 If we want `extra-paths`, we can define them as normal paths or as unix
 wildcards (see `fnmatch` module) ::
+
     >>> write('buildout.cfg',
     ... """
     ... [buildout]


### PR DESCRIPTION
(Missing blank line before indent, this messed up the pypi page's formatting)
