### PR TITLE
Added python3 support

### DIFF
--- a/src/collective/recipe/sphinxbuilder/__init__.py
+++ b/src/collective/recipe/sphinxbuilder/__init__.py
@@ -8,7 +8,10 @@ import sys
 import zc.buildout
 import zc.recipe.egg
 from fnmatch import fnmatch
-from cStringIO import StringIO
+try:
+    from io import StringIO  # Python 3
+except ImportError:
+    from cStringIO import StringIO  # Python 2
 
 log = logging.getLogger(__name__)
 
@@ -66,8 +69,8 @@ class Recipe(object):
                         extra_paths.append(filename)
             sys.path.extend(extra_paths)
 
-        from utils import MAKEFILE
-        from utils import BATCHFILE
+        from .utils import MAKEFILE
+        from .utils import BATCHFILE
 
         # and cleanup again
         if extra_paths:
@@ -108,7 +111,7 @@ class Recipe(object):
                 latex = 'make latex && '
             script.append(latex+'cd %s && make all-pdf' % os.path.join(self.build_dir, 'latex'))
         self._write_file(self.script_path, '\n'.join(script))
-        os.chmod(self.script_path, 0777)
+        os.chmod(self.script_path, 0o777)
 
         # 5. INSTALL SPHINX WITH SCRIPT AND EXTRA PATHS
 

--- a/src/collective/recipe/sphinxbuilder/__init__.py
+++ b/src/collective/recipe/sphinxbuilder/__init__.py
@@ -8,10 +8,6 @@ import sys
 import zc.buildout
 import zc.recipe.egg
 from fnmatch import fnmatch
-try:
-    from io import StringIO  # Python 3
-except ImportError:
-    from cStringIO import StringIO  # Python 2
 
 log = logging.getLogger(__name__)
 
@@ -148,15 +144,15 @@ class Recipe(object):
         # change last line from sphinx.main() to sys.exit(sphinx.main())
         # so that errors are correctly reported to Travis CI.
         sb = os.path.join(self.bin_dir, 'sphinx-build')
-        temp_file = StringIO()
+        temp_lines = []
         sb_file = open(sb, 'r')
         for line in sb_file:
-            temp_file.write(line.replace('sphinx.main()', 'sys.exit(sphinx.main())'))
-        # open for writing (delete contents existing contents before rewriting
-        # from StringIO that contains the modification
+            temp_lines.append(line.replace('sphinx.main()', 'sys.exit(sphinx.main())'))
+        # open for writing (which deletes existing contents before rewriting
+        # from temp_lines that contains the modification)
         sb_file = open(sb, 'w')
-        sb_file.write(temp_file.getvalue())
-        temp_file.close()
+        for line in temp_lines:
+            sb_file.write(line)
         sb_file.close()
 
         return [self.script_path, self.makefile_path, self.batchfile_path]

--- a/src/collective/recipe/sphinxbuilder/__init__.py
+++ b/src/collective/recipe/sphinxbuilder/__init__.py
@@ -147,7 +147,12 @@ class Recipe(object):
         temp_lines = []
         sb_file = open(sb, 'r')
         for line in sb_file:
-            temp_lines.append(line.replace('sphinx.main()', 'sys.exit(sphinx.main())'))
+            if 'sphinx.main()' in line:
+                replacement = 'sys.exit(sphinx.main())'
+                if not replacement in line:
+                    # Buildout 2.x already includes sys.exit()
+                    line = line.replace('sphinx.main()', replacement)
+            temp_lines.append(line)
         # open for writing (which deletes existing contents before rewriting
         # from temp_lines that contains the modification)
         sb_file = open(sb, 'w')

--- a/src/collective/recipe/sphinxbuilder/docs/history.rst
+++ b/src/collective/recipe/sphinxbuilder/docs/history.rst
@@ -2,6 +2,12 @@
 Changes
 =======
 
+
+0.7.5 (unreleased)
+==================
+
+  - Added python 3 support [reinout]
+
 0.7.4 (2013-11-15)
 ==================
 
@@ -93,4 +99,3 @@ Changes
 
  - Initial implementation [Tarek Ziade]
  - Created recipe with ZopeSkel [Tarek Ziade].
-

--- a/src/collective/recipe/sphinxbuilder/docs/usage.rst
+++ b/src/collective/recipe/sphinxbuilder/docs/usage.rst
@@ -17,7 +17,7 @@ buildout that uses the recipe::
 
 Let's run the buildout::
 
-    >>> print('start', system(buildout))
+    >>> print('start ' + system(buildout))
     ... # doctest: +ELLIPSIS
     start Installing sphinxbuilder.
     collective.recipe.sphinxbuilder: writing MAKEFILE..
@@ -56,7 +56,7 @@ The content of the script is a simple shell script::
     cd ...docs
     make html
 
-    >>> print('start', system(script))
+    >>> print('start ' + system(script))
     start /sample-buildout/bin/sphinx-build -b html -d /sample-buildout/docs/doctrees ...src/collective/recipe/sphinxbuilder/docs /sample-buildout/docs/html
     ...
 
@@ -74,7 +74,7 @@ If we want `latex`, we need to explicitly define it::
     ...     html
     ...     latex
     ... """)
-    >>> print('start', system(buildout))
+    >>> print('start ' + system(buildout))
     ... # doctest: +ELLIPSIS
     start Uninstalling sphinxbuilder.
     Installing sphinxbuilder.
@@ -93,7 +93,7 @@ Let's see our script now::
 
 Finally let's run it::
 
-    >>> print('start', system(script))
+    >>> print('start ' + system(script))
     start /sample-buildout/bin/sphinx-build -b html -d /sample-buildout/docs/doctrees   .../src/collective/recipe/sphinxbuilder/docs /sample-buildout/docs/html
     ...
     <BLANKLINE>
@@ -119,7 +119,7 @@ If we want `pdf`, we need to explicitly define it::
     ...     latex
     ...     pdf
     ... """)
-    >>> print('start', system(buildout))
+    >>> print('start ' + system(buildout))
     ... # doctest: +ELLIPSIS
     start Uninstalling sphinxbuilder.
     Installing sphinxbuilder.
@@ -154,7 +154,7 @@ If we want `epub`, like pdf we need to explicitly define it::
     ...     html
     ...     epub
     ... """)
-    >>> print('start', system(buildout))
+    >>> print('start ' + system(buildout))
     ... # doctest: +ELLIPSIS
     start Uninstalling sphinxbuilder.
     Installing sphinxbuilder.
@@ -185,7 +185,7 @@ We can also have the script run any doctests in the docs while building::
     ...     doctest
     ...     html
     ... """)
-    >>> print('start', system(buildout))
+    >>> print('start ' + system(buildout))
     ... # doctest: +ELLIPSIS
     start Uninstalling sphinxbuilder.
     Installing sphinxbuilder.
@@ -218,7 +218,7 @@ wildcards (see `fnmatch` module) ::
     ...     develop-eggs/
     ...     eggs/*
     ... """)
-    >>> print('start', system(buildout))
+    >>> print('start ' + system(buildout))
     ... # doctest: +ELLIPSIS
     start Uninstalling sphinxbuilder.
     Installing sphinxbuilder.

--- a/src/collective/recipe/sphinxbuilder/docs/usage.rst
+++ b/src/collective/recipe/sphinxbuilder/docs/usage.rst
@@ -81,7 +81,6 @@ If we want `latex`, we need to explicitly define it::
     collective.recipe.sphinxbuilder: writing MAKEFILE..
     collective.recipe.sphinxbuilder: writing BATCHFILE..
     collective.recipe.sphinxbuilder: writing custom sphinx-builder script..
-    Generated script '/sample-buildout/bin/sphinx-build'.
     ...
 
 Let's see our script now::
@@ -126,7 +125,6 @@ If we want `pdf`, we need to explicitly define it::
     collective.recipe.sphinxbuilder: writing MAKEFILE..
     collective.recipe.sphinxbuilder: writing BATCHFILE..
     collective.recipe.sphinxbuilder: writing custom sphinx-builder script..
-    Generated script '/sample-buildout/bin/sphinx-build'.
     ...
 
 Let's see our script now::
@@ -161,7 +159,6 @@ If we want `epub`, like pdf we need to explicitly define it::
     collective.recipe.sphinxbuilder: writing MAKEFILE..
     collective.recipe.sphinxbuilder: writing BATCHFILE..
     collective.recipe.sphinxbuilder: writing custom sphinx-builder script..
-    Generated script '/sample-buildout/bin/sphinx-build'.
     ...
 
 Let's see our script now::
@@ -192,7 +189,6 @@ We can also have the script run any doctests in the docs while building::
     collective.recipe.sphinxbuilder: writing MAKEFILE..
     collective.recipe.sphinxbuilder: writing BATCHFILE..
     collective.recipe.sphinxbuilder: writing custom sphinx-builder script..
-    Generated script '/sample-buildout/bin/sphinx-build'.
     ...
 
 Let's see our script now::
@@ -226,5 +222,4 @@ wildcards (see `fnmatch` module) ::
     collective.recipe.sphinxbuilder: writing BATCHFILE..
     collective.recipe.sphinxbuilder: writing custom sphinx-builder script..
     collective.recipe.sphinxbuilder: inserting extra-paths..
-    Generated script '/sample-buildout/bin/sphinx-build'.
     ...

--- a/src/collective/recipe/sphinxbuilder/docs/usage.rst
+++ b/src/collective/recipe/sphinxbuilder/docs/usage.rst
@@ -17,7 +17,7 @@ buildout that uses the recipe::
 
 Let's run the buildout::
 
-    >>> print 'start', system(buildout)
+    >>> print('start', system(buildout))
     ... # doctest: +ELLIPSIS
     start Installing sphinxbuilder.
     collective.recipe.sphinxbuilder: writing MAKEFILE..
@@ -52,11 +52,11 @@ A script in the `bin` folder to build the docs::
 The content of the script is a simple shell script::
 
     >>> script = join(sample_buildout, 'bin', 'sphinxbuilder')
-    >>> print open(script).read()
+    >>> print(open(script).read())
     cd ...docs
     make html
 
-    >>> print 'start', system(script)
+    >>> print('start', system(script))
     start /sample-buildout/bin/sphinx-build -b html -d /sample-buildout/docs/doctrees ...src/collective/recipe/sphinxbuilder/docs /sample-buildout/docs/html
     ...
 
@@ -74,7 +74,7 @@ If we want `latex`, we need to explicitly define it::
     ...     html
     ...     latex
     ... """)
-    >>> print 'start', system(buildout)
+    >>> print('start', system(buildout))
     ... # doctest: +ELLIPSIS
     start Uninstalling sphinxbuilder.
     Installing sphinxbuilder.
@@ -93,7 +93,7 @@ Let's see our script now::
 
 Finally let's run it::
 
-    >>> print 'start', system(script)
+    >>> print('start', system(script))
     start /sample-buildout/bin/sphinx-build -b html -d /sample-buildout/docs/doctrees   .../src/collective/recipe/sphinxbuilder/docs /sample-buildout/docs/html
     ...
     <BLANKLINE>
@@ -119,7 +119,7 @@ If we want `pdf`, we need to explicitly define it::
     ...     latex
     ...     pdf
     ... """)
-    >>> print 'start', system(buildout)
+    >>> print('start', system(buildout))
     ... # doctest: +ELLIPSIS
     start Uninstalling sphinxbuilder.
     Installing sphinxbuilder.
@@ -154,7 +154,7 @@ If we want `epub`, like pdf we need to explicitly define it::
     ...     html
     ...     epub
     ... """)
-    >>> print 'start', system(buildout)
+    >>> print('start', system(buildout))
     ... # doctest: +ELLIPSIS
     start Uninstalling sphinxbuilder.
     Installing sphinxbuilder.
@@ -185,7 +185,7 @@ We can also have the script run any doctests in the docs while building::
     ...     doctest
     ...     html
     ... """)
-    >>> print 'start', system(buildout)
+    >>> print('start', system(buildout))
     ... # doctest: +ELLIPSIS
     start Uninstalling sphinxbuilder.
     Installing sphinxbuilder.
@@ -218,7 +218,7 @@ wildcards (see `fnmatch` module) ::
     ...     develop-eggs/
     ...     eggs/*
     ... """)
-    >>> print 'start', system(buildout)
+    >>> print('start', system(buildout))
     ... # doctest: +ELLIPSIS
     start Uninstalling sphinxbuilder.
     Installing sphinxbuilder.

--- a/src/collective/recipe/sphinxbuilder/docs/usage.rst
+++ b/src/collective/recipe/sphinxbuilder/docs/usage.rst
@@ -26,8 +26,7 @@ Let's run the buildout::
     Generated script '/sample-buildout/bin/sphinx-quickstart'.
     Generated script '/sample-buildout/bin/sphinx-build'.
     Generated script '/sample-buildout/bin/sphinx-apidoc'.
-    Generated script '/sample-buildout/bin/sphinx-autogen'.
-    ...
+    Generated script '/sample-buildout/bin/sphinx-autogen'...
 
 What are we expecting?
 
@@ -80,8 +79,7 @@ If we want `latex`, we need to explicitly define it::
     Installing sphinxbuilder.
     collective.recipe.sphinxbuilder: writing MAKEFILE..
     collective.recipe.sphinxbuilder: writing BATCHFILE..
-    collective.recipe.sphinxbuilder: writing custom sphinx-builder script..
-    ...
+    collective.recipe.sphinxbuilder: writing custom sphinx-builder script...
 
 Let's see our script now::
 
@@ -124,8 +122,7 @@ If we want `pdf`, we need to explicitly define it::
     Installing sphinxbuilder.
     collective.recipe.sphinxbuilder: writing MAKEFILE..
     collective.recipe.sphinxbuilder: writing BATCHFILE..
-    collective.recipe.sphinxbuilder: writing custom sphinx-builder script..
-    ...
+    collective.recipe.sphinxbuilder: writing custom sphinx-builder script...
 
 Let's see our script now::
 
@@ -158,8 +155,7 @@ If we want `epub`, like pdf we need to explicitly define it::
     Installing sphinxbuilder.
     collective.recipe.sphinxbuilder: writing MAKEFILE..
     collective.recipe.sphinxbuilder: writing BATCHFILE..
-    collective.recipe.sphinxbuilder: writing custom sphinx-builder script..
-    ...
+    collective.recipe.sphinxbuilder: writing custom sphinx-builder script...
 
 Let's see our script now::
 
@@ -188,8 +184,7 @@ We can also have the script run any doctests in the docs while building::
     Installing sphinxbuilder.
     collective.recipe.sphinxbuilder: writing MAKEFILE..
     collective.recipe.sphinxbuilder: writing BATCHFILE..
-    collective.recipe.sphinxbuilder: writing custom sphinx-builder script..
-    ...
+    collective.recipe.sphinxbuilder: writing custom sphinx-builder script...
 
 Let's see our script now::
 
@@ -221,5 +216,4 @@ wildcards (see `fnmatch` module) ::
     collective.recipe.sphinxbuilder: writing MAKEFILE..
     collective.recipe.sphinxbuilder: writing BATCHFILE..
     collective.recipe.sphinxbuilder: writing custom sphinx-builder script..
-    collective.recipe.sphinxbuilder: inserting extra-paths..
-    ...
+    collective.recipe.sphinxbuilder: inserting extra-paths...

--- a/src/collective/recipe/sphinxbuilder/tests/test_docs.py
+++ b/src/collective/recipe/sphinxbuilder/tests/test_docs.py
@@ -7,10 +7,14 @@ __docformat__ = 'restructuredtext'
 import doctest
 import pkg_resources
 import unittest
+import re
 import zc.buildout.tests
 import zc.buildout.testing
 from zope.testing import renormalizing
 
+
+# 'Not found: xyz' setuptools message suppressor. Copied from zc.buildout.
+not_found = (re.compile(r'Not found: [^\n]+/(\w|\.)+/\r?\n'), '')
 
 optionflags =  (doctest.ELLIPSIS |
                 doctest.NORMALIZE_WHITESPACE |
@@ -32,7 +36,7 @@ def get_dependent_dists(pkg):
         ]:
         result.append(name)
     return result
-                      
+
 
 def setUp(test):
     zc.buildout.testing.buildoutSetUp(test)
@@ -58,6 +62,7 @@ def test_suite():
                         # second item, e.g.
                         # (re.compile('my-[rR]eg[eE]ps'), 'my-regexps')
                         zc.buildout.testing.normalize_path,
+                        not_found,
                         ]),
                 ),
             ))

--- a/src/collective/recipe/sphinxbuilder/tests/test_docs.py
+++ b/src/collective/recipe/sphinxbuilder/tests/test_docs.py
@@ -49,23 +49,23 @@ def setUp(test):
 
 def test_suite():
     suite = unittest.TestSuite((
-            doctest.DocFileSuite(
-                '../docs/usage.rst',
-                setUp=setUp,
-                tearDown=zc.buildout.testing.buildoutTearDown,
-                optionflags=optionflags,
-                checker=renormalizing.RENormalizing([
-                        # If want to clean up the doctest output you
-                        # can register additional regexp normalizers
-                        # here. The format is a two-tuple with the RE
-                        # as the first item and the replacement as the
-                        # second item, e.g.
-                        # (re.compile('my-[rR]eg[eE]ps'), 'my-regexps')
-                        zc.buildout.testing.normalize_path,
-                        not_found,
-                        ]),
-                ),
-            ))
+        doctest.DocFileSuite(
+            '../docs/usage.rst',
+            setUp=setUp,
+            tearDown=zc.buildout.testing.buildoutTearDown,
+            optionflags=optionflags,
+            checker=renormalizing.RENormalizing([
+                # If want to clean up the doctest output you
+                # can register additional regexp normalizers
+                # here. The format is a two-tuple with the RE
+                # as the first item and the replacement as the
+                # second item, e.g.
+                # (re.compile('my-[rR]eg[eE]ps'), 'my-regexps')
+                zc.buildout.testing.normalize_path,
+                not_found,
+            ]),
+        ),
+    ))
     return suite
 
 if __name__ == '__main__':


### PR DESCRIPTION
Various relatively small fixes to get it working on python 2 and 3. `0o777` instead of `0777` as octal syntax, for instance. `print(xyz)` instead of `print xyz` in the doctest.

At the same time I added some adjustments for buildout 2.x (bin/sphinx would contain `sys.exit(sys.exit(...))` as buildout 2 itself already adds the `sys.exit()` now).

I kept the tests running. I had to add an extra renormalizer (copied from zc.buildout) to suppress messages from newer setuptools.

I tested it (bootstrap, bin/buildout, bin/test) with python 3.3, 2.6 and 2.7. 2.5 already fails because of some setuptools thingy.

(Note: also accept my other pull request before doing any release as there's a .rst error in `usage.txt` now which breaks the pypi page rendering).
