### PR TITLE
Tiny change to prevent a non-critical warning when installing on python3

### DIFF
--- a/src/collective/recipe/sphinxbuilder/docs/conf.py
+++ b/src/collective/recipe/sphinxbuilder/docs/conf.py
@@ -168,8 +168,7 @@ htmlhelp_basename = 'SphinxBuilderdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class [howto/manual]).
 latex_documents = [
-  ('index', 'SphinxBuilder.tex', ur'',
-   ur'', 'manual'),
+    ('index', 'SphinxBuilder.tex', '', '', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/src/collective/recipe/sphinxbuilder/docs/history.rst
+++ b/src/collective/recipe/sphinxbuilder/docs/history.rst
@@ -3,6 +3,11 @@ Changes
 =======
 
 
+0.8.1 (unreleased)
+==================
+
+  - Prevent a warning when installing with python 3 [reinout]
+
 0.8.0 (2013-11-27)
 ==================
 


### PR DESCRIPTION
I got an error like this when installing under python 3:

```
Getting distribution for 'collective.recipe.sphinxbuilder'.
warning: no files found matching '*.txt'
warning: no previously-included files matching '*pyc' found anywhere in distribution
  File "..../collective/recipe/sphinxbuilder/docs/conf.py", line 171
    ('index', 'SphinxBuilder.tex', ur'',
                                      ^
SyntaxError: invalid syntax

  File "..../collective.recipe.sphinxbuilder-0.8.0-py3.3.egg/collective/recipe/sphinxbuilder/docs/conf.py", line 171
    ('index', 'SphinxBuilder.tex', ur'',
                                      ^
SyntaxError: invalid syntax

Got collective.recipe.sphinxbuilder 0.8.0.
```

It is an error that doesn't break the install, but the fix was easy and straightforward.
