### PR TITLE
added rst2pdf builder

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
-version = '0.8.2'
+version = '0.8.3'
 
 long_description = (
     read('README.rst')

--- a/src/collective/recipe/sphinxbuilder/__init__.py
+++ b/src/collective/recipe/sphinxbuilder/__init__.py
@@ -97,11 +97,13 @@ class Recipe(object):
             script.append('make doctest')
         if 'html' in self.outputs:
             script.append('make html')
+        if 'rst2pdf' in self.outputs:
+            script.append('make rst2pdf')
         if 'latex' in self.outputs:
             script.append('make latex')
         if 'epub' in self.outputs:
             script.append('make epub')
-        if 'pdf' in self.outputs:
+        if 'pdf' in self.outputs and not 'rst2pdf' in self.outputs:
             latex = ''
             if 'latex' not in self.outputs:
                 latex = 'make latex && '

--- a/src/collective/recipe/sphinxbuilder/utils.py
+++ b/src/collective/recipe/sphinxbuilder/utils.py
@@ -33,6 +33,7 @@ help:
 \t@echo "  epub       to make an epub"
 \t@echo "  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
 \t@echo "  latexpdf   to make LaTeX files and run them through pdflatex"
+\t@echo "  rst2pdf    to make rst2pdf"
 \t@echo "  text       to make text files"
 \t@echo "  man        to make manual pages"
 \t@echo "  texinfo    to make Texinfo files"
@@ -112,6 +113,11 @@ latex:
 \t@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
 \t@echo "Run \\`make' in that directory to run these through (pdf)latex" \\
 \t      "(use \\`make latexpdf' here to do that automatically)."
+
+rst2pdf:
+\t$(SPHINXBUILD) -b pdf $(ALLSPHINXOPTS) $(BUILDDIR)/pdf
+\t@echo
+\t@echo "Build finished; the PDF files are in $(BUILDDIR)/pdf."
 
 latexpdf:
 \t$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex


### PR DESCRIPTION
Hi.

Currenlty sphinxbuilder only supports building PDF files with Latex. 
Here is a small quirck to also add the possibility to build PDF files with the rst2pdf plugin. Just provide the rst2pdf option switch instead of pdf in the buildout file. 
